### PR TITLE
Fix empty workflow summary padding

### DIFF
--- a/frontend/src/assets/styles/main.scss
+++ b/frontend/src/assets/styles/main.scss
@@ -21,4 +21,6 @@
   --font-m: #{$f-m};
   --font-l: #{$f-l};
   --font-xl: #{$f-xl};
+  --bp-tablet: #{$bp-tablet};
+  --bp-mobile: #{$bp-mobile};
 }

--- a/frontend/src/components/organisms/WorkflowSummary.vue
+++ b/frontend/src/components/organisms/WorkflowSummary.vue
@@ -128,5 +128,9 @@ const title = computed(() => {
     padding: $s $xs;
     padding-top: 0;
   }
+
+  &__content {
+    padding: $s $xs;
+  }
 }
 </style>

--- a/frontend/src/helpers/nodeHelper.ts
+++ b/frontend/src/helpers/nodeHelper.ts
@@ -1,4 +1,4 @@
-import type { FrontendNode } from '../types/workflow';
+import type { FrontendNode } from '@/types/workflow';
 
 export class NodeHelper {
   /** Determine if a node is compatible in the current frontend stage */

--- a/frontend/src/stores/global.ts
+++ b/frontend/src/stores/global.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { cssVariables } from '@/utils/cssVariables';
 
 interface GlobalStore {
   spinnerVisible: boolean;
@@ -11,6 +12,6 @@ export const useGlobalStore = defineStore('global', {
     windowWidth: window.innerWidth,
   }),
   getters: {
-    isMobile: (state) => state.windowWidth < 768,
+    isMobile: (state) => state.windowWidth <= cssVariables.breakPoints.mobile,
   },
 });

--- a/frontend/src/utils/cssVariables.ts
+++ b/frontend/src/utils/cssVariables.ts
@@ -22,4 +22,8 @@ export const cssVariables = {
     l: getNumberFromCssVariable('--font-l'),
     xl: getNumberFromCssVariable('--font-xl'),
   },
+  breakPoints: {
+    tablet: getNumberFromCssVariable('--bp-tablet'),
+    mobile: getNumberFromCssVariable('--bp-mobile'),
+  },
 };

--- a/frontend/src/views/WorkflowChecker.vue
+++ b/frontend/src/views/WorkflowChecker.vue
@@ -514,6 +514,10 @@ onUnmounted(() => {
     z-index: 1;
     grid-column: 9 / span 2;
 
+    @media screen and (width <= $bp-tablet) {
+      grid-column: 6 / span 2;
+    }
+
     @media screen and (width <= $bp-mobile) {
       position: absolute;
       bottom: 0;


### PR DESCRIPTION
* Fix empty workflow summary padding introduced with mobile version
* Fix summary grid span on tablet
* fix global isMobile Breakpoint in JS
* use CSS var for breakpoint in JS